### PR TITLE
perf: set explicit Timeout on the insecure-mode PagerDuty *http.Client

### DIFF
--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"net/http"
+	"time"
 
 	"github.com/PagerDuty/go-pagerduty"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -162,6 +163,7 @@ func New(ctx context.Context, accessToken string, baseURL string, insecure bool)
 
 	if insecure {
 		client.HTTPClient = &http.Client{
+			Timeout: 30 * time.Second,
 			Transport: &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // G402: intentional for testing with self-signed certs
 			},


### PR DESCRIPTION
When the connector is configured with the \`insecure\` flag the default pagerduty SDK client is swapped for an \`*http.Client\` with a custom Transport (\`TLSClientConfig{InsecureSkipVerify: true}\`). The replacement had no \`Timeout\`, so a hung server stalls the request indefinitely once we leave the SDK's default client.

The insecure path is the dev / self-signed-cert testing path, but the same Timeout discipline that applies to the default client should apply here.

Added a 30s \`Timeout\` matching the baton-sdk \`uhttp\` transport defaults.

How found: occult-go-analysis baton pool scan (2026-05-20), detector \`http_client_literal_without_timeout\`.